### PR TITLE
Change search provider to Apple's Map Kit

### DIFF
--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -171,16 +171,14 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         search.start(completionHandler: searchWithTextCallback)
     }
     
-    private func searchWithTextCallback(response: MKLocalSearch.Response?, error: Error?) {
-(response, error) in
-            guard error == nil else {
-                return
-            }
-            var pois: [POI] = []
-            for result in response?.mapItems ?? [] {
-                        let poi = GenericLocation(lat: result.placemark.location?.coordinate.latitude?, lon: result.placemark.location?.coordinate.longitude?, name: result.name?)
-                pois.append(poi)
-            }
+    private func searchWithTextCallback(response: MKLocalSearch.Response?, error: Error?) -> Void {
+        guard error == nil else {
+            return
+        }
+        var pois: [POI] = []
+        for result in response?.mapItems ?? [] {
+            pois.append(GenericLocation(lat: result.placemark.location?.coordinate.latitude?, lon: result.placemark.location?.coordinate.longitude?, name: result.name?))
+        }
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location?)
     }
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -166,7 +166,8 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         
         let request = MKLocalSearch.Request()
         request.naturalLanguageQuery = searchText
-        request.region = MKCoordinateRegion(center: self.location?.coordinate?, latitudinalMeters: 75000, longitudinalMeters: 75000)
+        let coordinate = self.location!.coordinate
+        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 75000, longitudinalMeters: 75000)
         let search = MKLocalSearch(request: request)
         search.start(completionHandler: searchWithTextCallback)
     }
@@ -176,9 +177,14 @@ extension SearchResultsUpdater: UISearchBarDelegate {
             return
         }
         var pois: [POI] = []
-        for result: MKMapItem in response?.mapItems {
-            pois.append(GenericLocation(lat: result.placemark.location?.coordinate.latitude?, lon: result.placemark.location?.coordinate.longitude?, name: result.name?))
+        if let mapItems = response?.mapItems {
+            for result in mapItems {
+                let lat = result.placemark.location?.coordinate.latitude
+                let long = result.placemark.location?.coordinate.longitude
+                pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!))
+            }
         }
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)
     }
+    
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -184,7 +184,7 @@ extension SearchResultsUpdater: UISearchBarDelegate {
             for result in mapItems {
                 let lat = result.placemark.location?.coordinate.latitude
                 let long = result.placemark.location?.coordinate.longitude
-                pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!))
+                pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!, address: result.placemark.name))
             }
         }
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -171,14 +171,14 @@ extension SearchResultsUpdater: UISearchBarDelegate {
         search.start(completionHandler: searchWithTextCallback)
     }
     
-    private func searchWithTextCallback(response: MKLocalSearch.Response?, error: Error?) -> Void {
+    private func searchWithTextCallback(using response: MKLocalSearch.Response?, error: Error?) -> Void {
         guard error == nil else {
             return
         }
         var pois: [POI] = []
-        for result in response?.mapItems ?? [] {
+        for result: MKMapItem in response?.mapItems {
             pois.append(GenericLocation(lat: result.placemark.location?.coordinate.latitude?, lon: result.placemark.location?.coordinate.longitude?, name: result.name?))
         }
-        delegate?.searchResultsDidUpdate(pois, searchLocation: self.location?)
+        delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)
     }
 }

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -184,7 +184,27 @@ extension SearchResultsUpdater: UISearchBarDelegate {
             for result in mapItems {
                 let lat = result.placemark.location?.coordinate.latitude
                 let long = result.placemark.location?.coordinate.longitude
-                pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!, address: result.placemark.name))
+                var addressParts: [String] = []
+                if let substreet = result.placemark.subThoroughfare {
+                    addressParts.append(substreet)
+                }
+                if let street = result.placemark.thoroughfare {
+                    addressParts.append(street + ",")
+                }
+                if let city = result.placemark.locality {
+                    addressParts.append(city)
+                }
+                if let state = result.placemark.administrativeArea {
+                    addressParts.append(state + ",")
+                }
+                if let postalCode = result.placemark.postalCode {
+                    addressParts.append(postalCode + ",")
+                }
+                if let country = result.placemark.country {
+                    addressParts.append(country)
+                }
+                let address = addressParts.joined(separator: " ")
+                pois.append(GenericLocation(lat: lat!, lon: long!, name: result.name!, address: address))
             }
         }
         delegate?.searchResultsDidUpdate(pois, searchLocation: self.location)

--- a/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
+++ b/apps/ios/GuideDogs/Code/Visual UI/Helpers/Search/SearchResultsUpdater.swift
@@ -122,9 +122,12 @@ extension SearchResultsUpdater: UISearchResultsUpdating {
         // Fetch autosuggest results with new search text
         //
 
-        ///FIXME leaving this empty for now
-        /// We can limit the load on the API server by only executing searches when typing is done.
-        /// When "enter" is pressed, the searchWithText method below executes the query.
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = searchText
+        let coordinate = self.location!.coordinate
+        request.region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 75000, longitudinalMeters: 75000)
+        let search = MKLocalSearch(request: request)
+        search.start(completionHandler: searchWithTextCallback)
     }
 }
 


### PR DESCRIPTION
This changes the data source used for searches to use Apple's MapKit, specifically [MKLocalSearch](https://developer.apple.com/documentation/mapkit/mklocalsearch).
I also updated the search as you type function to use this as well.  
Though this has tradeoffs around things like cross-platform support, I believe its worth it right now to get good results and to have to run one less thing. Apple does provide [a server-side API](https://developer.apple.com/documentation/applemapsserverapi) for this data, which means we can still potentially keep the same provider across platforms if we want to in the future.