### PR TITLE
miner improvements to make_static_tiles.py

### DIFF
--- a/svcs/data/make_static_tiles.py
+++ b/svcs/data/make_static_tiles.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
         tile_dir = args.output_dir / z / x
         tile_dir.mkdir(parents=True, exist_ok=True)
         tile_path = tile_dir / f"{y}.json.bz2"
+        if tile_path.exists():
+            continue
         output = tile(cursor, x, y, z)
         if output:
             nonempty_tiles += 1

--- a/svcs/data/make_static_tiles.py
+++ b/svcs/data/make_static_tiles.py
@@ -44,10 +44,10 @@ if __name__ == "__main__":
         tile_dir = args.output_dir / z / x
         tile_dir.mkdir(parents=True, exist_ok=True)
         tile_path = tile_dir / f"{y}.json"
-        with open(tile_path, "w") as f:
-            output = tile(cursor, x, y, z)
-            if output:
-                nonempty_tiles += 1
+        output = tile(cursor, x, y, z)
+        if output:
+            nonempty_tiles += 1
+            with open(tile_path, "w") as f:
                 f.write(output)
 
     print(f"Tiles in region: {total_tiles}")

--- a/svcs/data/make_static_tiles.py
+++ b/svcs/data/make_static_tiles.py
@@ -44,12 +44,12 @@ if __name__ == "__main__":
         total_tiles += 1
         x, y, z = line.strip().split(",")
         tile_dir = args.output_dir / z / x
-        tile_dir.mkdir(parents=True, exist_ok=True)
         tile_path = tile_dir / f"{y}.json.bz2"
         if tile_path.exists():
             continue
         output = tile(cursor, x, y, z)
         if output:
+            tile_dir.mkdir(parents=True, exist_ok=True)
             nonempty_tiles += 1
             with bz2.open(tile_path, "w") as f:
                 f.write(output.encode())

--- a/svcs/data/make_static_tiles.py
+++ b/svcs/data/make_static_tiles.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         if output:
             nonempty_tiles += 1
             with bz2.open(tile_path, "w") as f:
-                f.write(output)
+                f.write(output.encode())
 
     print(f"Tiles in region: {total_tiles}")
     print(f"Tiles with features: {nonempty_tiles}")

--- a/svcs/data/make_static_tiles.py
+++ b/svcs/data/make_static_tiles.py
@@ -11,6 +11,8 @@ import sys
 import psycopg2
 from psycopg2.extras import NamedTupleCursor
 
+import bz2
+
 tile_query = """
     SELECT * from soundscape_tile(%(zoom)s, %(tile_x)s, %(tile_y)s)
 """
@@ -43,11 +45,11 @@ if __name__ == "__main__":
         x, y, z = line.strip().split(",")
         tile_dir = args.output_dir / z / x
         tile_dir.mkdir(parents=True, exist_ok=True)
-        tile_path = tile_dir / f"{y}.json"
+        tile_path = tile_dir / f"{y}.json.bz2"
         output = tile(cursor, x, y, z)
         if output:
             nonempty_tiles += 1
-            with open(tile_path, "w") as f:
+            with bz2.open(tile_path, "w") as f:
                 f.write(output)
 
     print(f"Tiles in region: {total_tiles}")


### PR DESCRIPTION
* don't create empty tiles
* skip tiles that already exist to allow continuing an aborted run
* compress tiles using bzip2
* don't create empty directories