### PR TITLE
Remove Azure Notification Hub

### DIFF
--- a/apps/ios/GuideDogs.xcodeproj/project.pbxproj
+++ b/apps/ios/GuideDogs.xcodeproj/project.pbxproj
@@ -115,7 +115,6 @@
 		285C8B812304868F00E466DF /* ARHeadsetGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285C8B802304868E00E466DF /* ARHeadsetGenerator.swift */; };
 		285C8B83230496D900E466DF /* GlyphCallout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285C8B82230496D900E466DF /* GlyphCallout.swift */; };
 		286145EB2625099F000E5525 /* SDWebImage in Frameworks */ = {isa = PBXBuildFile; productRef = 286145EA2625099F000E5525 /* SDWebImage */; };
-		286145F1262509DA000E5525 /* WindowsAzureMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 286145F0262509DA000E5525 /* WindowsAzureMessaging */; };
 		2866A7C12625013400EBA2D8 /* DZNEmptyDataSet in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C02625013400EBA2D8 /* DZNEmptyDataSet */; };
 		2866A7C72625020600EBA2D8 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C62625020600EBA2D8 /* AppCenterAnalytics */; };
 		2866A7C92625020600EBA2D8 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; productRef = 2866A7C82625020600EBA2D8 /* AppCenterCrashes */; };
@@ -1815,7 +1814,6 @@
 				2866A7C72625020600EBA2D8 /* AppCenterAnalytics in Frameworks */,
 				2866A7CF2625028600EBA2D8 /* Reachability in Frameworks */,
 				2866A7C92625020600EBA2D8 /* AppCenterCrashes in Frameworks */,
-				286145F1262509DA000E5525 /* WindowsAzureMessaging in Frameworks */,
 				286F409D2624FF6000C3F80B /* NVActivityIndicatorView in Frameworks */,
 				2866A7D5262502D500EBA2D8 /* CocoaLumberjackSwift in Frameworks */,
 				286145EB2625099F000E5525 /* SDWebImage in Frameworks */,
@@ -5150,7 +5148,6 @@
 				2866A7D4262502D500EBA2D8 /* CocoaLumberjackSwift */,
 				28F1ECE1262505DC00E964C0 /* Realm */,
 				286145EA2625099F000E5525 /* SDWebImage */,
-				286145F0262509DA000E5525 /* WindowsAzureMessaging */,
 				281BCBFE262638290031298D /* RealmSwift */,
 				283B0306264B03920092F74F /* SDWebImageSwiftUI */,
 			);
@@ -5224,7 +5221,6 @@
 				2866A7D3262502D500EBA2D8 /* XCRemoteSwiftPackageReference "CocoaLumberjack" */,
 				28F1ECE0262505DC00E964C0 /* XCRemoteSwiftPackageReference "realm-cocoa" */,
 				286145E92625099F000E5525 /* XCRemoteSwiftPackageReference "SDWebImage" */,
-				286145EF262509DA000E5525 /* XCRemoteSwiftPackageReference "azure-notificationhubs-ios" */,
 				283B0305264B03920092F74F /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */,
 			);
 			productRefGroup = D3D7CFC91B3D96470020B5E9 /* Products */;
@@ -6643,14 +6639,6 @@
 				minimumVersion = 5.13.2;
 			};
 		};
-		286145EF262509DA000E5525 /* XCRemoteSwiftPackageReference "azure-notificationhubs-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Azure/azure-notificationhubs-ios";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.1.5;
-			};
-		};
 		2866A7BF2625013400EBA2D8 /* XCRemoteSwiftPackageReference "DZNEmptyDataSet" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dzenbot/DZNEmptyDataSet";
@@ -6716,11 +6704,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 286145E92625099F000E5525 /* XCRemoteSwiftPackageReference "SDWebImage" */;
 			productName = SDWebImage;
-		};
-		286145F0262509DA000E5525 /* WindowsAzureMessaging */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 286145EF262509DA000E5525 /* XCRemoteSwiftPackageReference "azure-notificationhubs-ios" */;
-			productName = WindowsAzureMessaging;
 		};
 		2866A7C02625013400EBA2D8 /* DZNEmptyDataSet */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/apps/ios/GuideDogs.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/apps/ios/GuideDogs.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "azure-notificationhubs-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Azure/azure-notificationhubs-ios",
-      "state" : {
-        "revision" : "f16d75b983a011ea60c596afe01d067870970ca7",
-        "version" : "3.1.5"
-      }
-    },
-    {
       "identity" : "cocoalumberjack",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/CocoaLumberjack/CocoaLumberjack",

--- a/apps/ios/GuideDogs/Code/App/Push Notifications/PushNotificationManager.swift
+++ b/apps/ios/GuideDogs/Code/App/Push Notifications/PushNotificationManager.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import Combine
-import WindowsAzureMessaging
 
 extension Notification.Name {
     static let pushNotificationReceived = Notification.Name("GDAPushNotificationReceived")
@@ -22,18 +21,7 @@ class PushNotificationManager: NSObject {
     struct NotificationKeys {
         static let pushNotification = "GDAPushNotification"
     }
-    
-    private struct InfoPlistKeys {
-        struct AzureNHConnectionString {
-            static let `default` = "SOUNDSCAPE_AZURE_NH_CONNECTION_STRING"
-            static let dogfood = "SOUNDSCAPE_AZURE_DF_NH_CONNECTION_STRING"
-        }
-        struct AzureNHPath {
-            static let `default` = "SOUNDSCAPE_AZURE_NH_PATH"
-            static let dogfood = "SOUNDSCAPE_AZURE_DF_NH_PATH"
-        }
-    }
-    
+
     private static var globalTags: [String: String] {
         let tags = [
             "device.model": UIDevice.current.modelName,
@@ -49,33 +37,6 @@ class PushNotificationManager: NSObject {
         ].mapValues { $0.lowercased().replace(characterSet: .whitespacesAndNewlines, with: "-") }
         
         return tags
-    }
-    
-    // MARK: - Properties
-    
-    private static var azureConnectionString: String? {
-        let key = BuildSettings.source == .appCenter ?
-            InfoPlistKeys.AzureNHConnectionString.dogfood :
-            InfoPlistKeys.AzureNHConnectionString.default
-        
-        guard let azureConnectionString = Bundle.main.infoPlistValue(forKey: key) else {
-            GDLogPushError("Error: The Azure connection string was not found in the Info.plist file. Please set a valid value for key '\(key)'")
-            return nil
-        }
-        
-        return azureConnectionString
-    }
-    private static var azureNotificationHubPath: String? {
-        let key = BuildSettings.source == .appCenter ?
-            InfoPlistKeys.AzureNHPath.dogfood :
-            InfoPlistKeys.AzureNHPath.default
-        
-        guard let azureNotificationHubPath = Bundle.main.infoPlistValue(forKey: key) else {
-            GDLogPushError("Error: The Azure notification hub path was not found in the Info.plist file. Please set a valid value for key '\(key)'")
-            return nil
-        }
-        
-        return azureNotificationHubPath
     }
     
     // MARK: - Properties
@@ -98,11 +59,7 @@ class PushNotificationManager: NSObject {
         super.init()
         
         UNUserNotificationCenter.current().delegate = self
-        
-        MSNotificationHub.setDelegate(self)
-        MSNotificationHub.setLifecycleDelegate(self)
-        MSNotificationHub.setEnrichmentDelegate(self)
-        
+
         self.userId = userId
         self.onboardingDidComplete = FirstUseExperience.didComplete(.oobe)
         
@@ -149,66 +106,14 @@ class PushNotificationManager: NSObject {
             // to approve notification permissions
             return
         }
-        
-        guard let connectionString = PushNotificationManager.azureConnectionString,
-              let hubName = PushNotificationManager.azureNotificationHubPath else {
-                  GDLogPushError("Error: The Azure notification hub connection string or hub name was not found in the Info.plist file")
-                  return
-              }
-        
-        MSNotificationHub.start(connectionString: connectionString, hubName: hubName)
     }
     
     private func updateUserIdIfNeeded(userId: String) {
-        guard userId != MSNotificationHub.getUserId() else {
-            return
-        }
-        
-        MSNotificationHub.setUserId(userId)
+        //XXX removed Azure-specific implementation
     }
     
-    /// Compares the global tags to the `MSNotificationHub` tags and updates values as needed
     private func updateTagsIfNeeded() {
-        let globalTags = PushNotificationManager.globalTags
-        let currentTags = MSNotificationHub.getTags()
-        
-        var tagsToRemove: [String] = []
-        var tagsToAdd: [String] = []
-        
-        for (globalTagKey, globalTagValue) in globalTags {
-            let globalTag = "\(globalTagKey):\(globalTagValue)"
-            
-            guard let currentTag = currentTags.first(where: { $0.hasPrefix(globalTagKey) }) else {
-                // Global tag does not exists in notification hub tags, add it.
-                tagsToAdd.append(globalTag)
-                continue
-            }
-            
-            let parts = currentTag.split(separator: ":")
-            guard parts.count == 2 else {
-                // Valid global tag should have the format "key:value"
-                continue
-            }
-            
-            let currentTagValue = String(parts[1])
-            
-            if currentTagValue != globalTagValue {
-                // Global tag has changed, clear old value and update new one.
-                // For example, iOS has been updated: "device.os.version:14.0" -> "device.os.version:14.1"
-                tagsToRemove.append(currentTag)
-                tagsToAdd.append(globalTag)
-            }
-        }
-        
-        if !tagsToRemove.isEmpty {
-            GDLogPushInfo("Removing tags: \(tagsToRemove)")
-            MSNotificationHub.removeTags(tagsToRemove)
-        }
-        
-        if !tagsToAdd.isEmpty {
-            GDLogPushInfo("Adding tags: \(tagsToAdd)")
-            MSNotificationHub.addTags(tagsToAdd)
-        }
+        //XXX removed Azure-specific implementation
     }
     
     func didFinishLaunchingWithOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any]) {
@@ -265,68 +170,6 @@ class PushNotificationManager: NSObject {
             didReceive(pushNotification: pendingPushNotification)
             self.pendingPushNotification = nil
         }
-    }
-    
-}
-
-// MARK: - MSNotificationHubDelegate
-
-extension PushNotificationManager: MSNotificationHubDelegate {
-    
-    func notificationHub(_ notificationHub: MSNotificationHub, didRequestAuthorization granted: Bool, error: Error?) {
-        if let error = error {
-            GDLogPushError("Error requesting authorization for push notifications: \(error.localizedDescription)")
-        } else {
-            GDLogPushInfo("Push notifications authorization \(granted ? "granted" : "denied")")
-        }
-        
-        GDATelemetry.track("push.request_authorization", with: ["granted": granted.description,
-                                                                "error": error?.localizedDescription ?? "none"])
-        
-        localPushNotificationManager.start()
-    }
-    
-    func notificationHub(_ notificationHub: MSNotificationHub, didReceivePushNotification message: MSNotificationHubMessage) {
-        defer {
-            if let notificationPresentationCompletion = notificationPresentationCompletion {
-                notificationPresentationCompletion([])
-                self.notificationPresentationCompletion = nil
-            }
-            
-            if let notificationResponseCompletion = notificationResponseCompletion {
-                notificationResponseCompletion()
-                self.notificationResponseCompletion = nil
-            }
-        }
-        
-        guard let userInfo = message.userInfo else { return }
-        let pushNotification = PushNotification(payload: userInfo)
-        
-        didReceive(pushNotification: pushNotification)
-    }
-    
-}
-
-// MARK: - MSInstallationLifecycleDelegate
-
-extension PushNotificationManager: MSInstallationLifecycleDelegate {
-    
-    func notificationHub(_ notificationHub: MSNotificationHub!, didSave installation: MSInstallation!) {
-        GDLogPushInfo("Successfully saved installation with ID: \(installation.installationId ?? "none")")
-    }
-    
-    func notificationHub(_ notificationHub: MSNotificationHub!, didFailToSave installation: MSInstallation!, withError error: Error!) {
-        GDLogPushError("Failed to save installation with ID: \(installation.installationId ?? "none") error: \(error?.localizedDescription ?? "none")")
-    }
-    
-}
-
-// MARK: - MSInstallationEnrichmentDelegate
-
-extension PushNotificationManager: MSInstallationEnrichmentDelegate {
-    
-    func notificationHub(_ notificationHub: MSNotificationHub!, willEnrichInstallation installation: MSInstallation!) {
-        GDLogPushInfo("Will enrich installation with ID: \(installation.installationId ?? "none")")
     }
     
 }


### PR DESCRIPTION
As requested in  #20. This change doesn't implement a replacement for sending push notifications; it just removes the package dependency and enough of the references so that the app still compiles.